### PR TITLE
Improve parallax performance

### DIFF
--- a/app/static/js/home/home.js
+++ b/app/static/js/home/home.js
@@ -20,7 +20,6 @@ $(function() {
         var $devfestbanner = $('.devfest-banner');
         var $nav = $('nav');
         var $hero = $('.hero');
-        var didScroll = false;
 
         var scrollHandler = function() {
             var scrolled = $(window).scrollTop();

--- a/app/static/js/home/home.js
+++ b/app/static/js/home/home.js
@@ -14,16 +14,19 @@ $(function() {
     });
 
 
-    var $image = $('.hero i');
     var md = new MobileDetect(window.navigator.userAgent);
-    var $devfestbanner = $('.devfest-banner');
-    var $nav = $('nav');
-    var $hero = $('.hero');
     if (md.mobile() == null) {
-        $(window).scroll(function(e){
+        var $image = $('.hero i');
+        var $devfestbanner = $('.devfest-banner');
+        var $nav = $('nav');
+        var $hero = $('.hero');
+        var didScroll = false;
+
+        var scrollHandler = function() {
             var scrolled = $(window).scrollTop();
             console.log(scrolled);
-            $image.css('transform','translateY(' + (scrolled/2) + 'px)');
+            $image.css('transform','translate3d(0px, ' + (scrolled/4) + 'px, 0px)');
+
             if ($devfestbanner !== undefined) {
                 if (scrolled > $hero.height()) {
                     $devfestbanner.addClass('up');
@@ -31,6 +34,10 @@ $(function() {
                     $devfestbanner.removeClass('up');
                 }
             }
+        }
+
+        $(window).on('scroll', function() {
+           window.requestAnimationFrame(scrollHandler);
         });
     }
 });

--- a/app/static/js/home/home.js
+++ b/app/static/js/home/home.js
@@ -16,6 +16,7 @@ $(function() {
 
     var md = new MobileDetect(window.navigator.userAgent);
     if (md.mobile() == null) {
+        var scroll_factor = 0.333333; // Image moves 1/3 as fast as body
         var $image = $('.hero i');
         var $devfestbanner = $('.devfest-banner');
         var $nav = $('nav');
@@ -23,13 +24,12 @@ $(function() {
 
         var scrollHandler = function() {
             var scrolled = $(window).scrollTop();
-            console.log(scrolled);
-            $image.css('transform','translate3d(0px, ' + (scrolled/4) + 'px, 0px)');
+            $image.css('transform','translate3d(0px, ' + (scrolled * scroll_factor) + 'px, 0px)');
 
             if ($devfestbanner !== undefined) {
                 if (scrolled > $hero.height()) {
                     $devfestbanner.addClass('up');
-                } else if (scrolled  <= 0) {
+                } else if (scrolled <= 0) {
                     $devfestbanner.removeClass('up');
                 }
             }

--- a/app/static/scss/client/client.scss
+++ b/app/static/scss/client/client.scss
@@ -119,6 +119,7 @@ $content-padding: 0.625rem;
 }
 
 $hero-height: 38rem;
+$hero-offset: 10rem;
 .hero {
     padding-top: $navbar-height;
     position: relative;
@@ -137,9 +138,10 @@ $hero-height: 38rem;
     i {
         z-index: 2;
         display: block;
-        height: ($hero-height + $navbar-height);
+        height: ($hero-height + $navbar-height + $hero-offset);
         width: 100%;
-        background-position: center center;
+        background-attachment: fixed;
+        background-position: center (-1 * $hero-offset);
         background-size: cover;
     }
 


### PR DESCRIPTION
- change `translateY` to `translate3d()`, which is [easier for browsers to animate](https://medium.com/@dhg/parallax-done-right-82ced812e61c#8f60)
- reduce parallax factor from 1/2 speed to 1/4
- use `window.requestAnimationFrame()` to register animation, as opposed to working directly in the scroll handler.
- extend the image upwards in CSS so that no gray bars will ever show behind the image if you scroll too fast.