### PR TITLE
Cleanup Events Page

### DIFF
--- a/app/routes/client.py
+++ b/app/routes/client.py
@@ -43,6 +43,7 @@ def index():
                    .order_by('start_date', 'start_time')
                    .limit(ONE_LARGE_AND_TRIPLE))
 
+    # sort published posts chronologically back in time
     all_blog_posts = (BlogPost.objects(published=True)
                               .order_by('-date_published'))
     latest_blog_post = all_blog_posts[0] if all_blog_posts else None
@@ -167,6 +168,7 @@ def events():
     recent_and_upcoming = Event.objects(published=True).order_by('start_date',
                                                                  'start_time')
 
+    # Sort recent events chronologically backwards in time
     recent_events = (recent_and_upcoming.filter(end_date__lt=today)
                                         .order_by('-start_date')
                                         .limit(NUM_PAST_EVENTS_FOR_FRONTPAGE))
@@ -200,7 +202,8 @@ def event_archive(index):
     if index <= 0:
         return redirect(url_for('.events'))
 
-    # Get all events that occur on this page or on subsequent pages
+    # Get all events that occur on this page or on subsequent pages, and order
+    # them chronologically back in time
     today = date.today()
     events = (Event.objects(published=True, end_date__lt=today)
                    .order_by('-start_date')

--- a/app/static/scss/client/client.scss
+++ b/app/static/scss/client/client.scss
@@ -197,6 +197,10 @@ $section-bottom: 1.25rem;
             padding-bottom: $section-bottom;
         }
 
+        h3.no-events {
+            margin: 4rem 0;
+        }
+
         h3 + h3 {
             margin-top: 1rem;
         }

--- a/app/templates/events/events.html
+++ b/app/templates/events/events.html
@@ -29,11 +29,20 @@
             <h4>Upcoming</h4>
             <span class="bar blue"></span>
         </div>
-        {% for event in upcoming_events %}
-            {{ macros.event(event) }}
-        {% endfor %}
+        {{ macros.event(upcoming_events[0]) }}
     </div>
 </section>
+{% if upcoming_events | length > 1 %}
+<section>
+    <div class="content">
+        <div class="triple">
+        {% for idx in range(1,4) %}
+            {{ macros.small_event(upcoming_events[idx]) }}
+        {% endfor %}
+        </div>
+    </div>
+</section>
+{% endif %}
 {% elif not events_this_week %}
     <div class="content">
         <div class="section-header">

--- a/app/templates/events/events.html
+++ b/app/templates/events/events.html
@@ -7,8 +7,8 @@
 <section class="tagline">
     <h1>Events</h1>
 </section>
-{% if events_this_week %}
 <section class="card top-card">
+{% if events_this_week %}
     <div class="content">
         <div class="section-header">
             <h4>This Week</h4>
@@ -18,14 +18,12 @@
             {{ macros.event(event) }}
         {% endfor %}
     </div>
-</section>
 {% endif %}
 {% if upcoming_events %}
-{% if events_this_week %}
+    {% if events_this_week %}
+</section>
 <section>
-{% else %}
-<section class="card top-card">
-{% endif %}
+    {% endif %}
     <div class="content">
         <div class="section-header">
             <h4>Upcoming</h4>
@@ -36,7 +34,16 @@
         {% endfor %}
     </div>
 </section>
+{% elif not events_this_week %}
+    <div class="content">
+        <div class="section-header">
+            <h4>Events</h4>
+            <span class="bar blue"></span>
+        </div>
+        <h3 class="no-events">We don't have any events this week.  Stay tooned for more events coming soon!</h3>
+    </div>
 {% endif %}
+</section>
 <section class="full green callout">
     <div class="content">
         <div class="callout-left">


### PR DESCRIPTION
Review: @eunicekokor @RaymondXu @natebrennand 

- use `.limit()` and `.skip()` for parsing through mongoengine queries, instead of slicing (e.g. `[:6]`). *Is this better?  It's much more readable, but maybe more confusing? Love some thoughts.*
- cleanup code style for mongo queries, aligning the chained methods
- Fix the order of past events and the event archive pages to now show events moving chronologically backwards instead of forwards....... (how did this bug exist for so long??)
- Fix edge cases where we have no upcoming events, no events this week, or neither.
- Now the six "previous events" on the `/events` page don't show up in the events archive (`/events/1`, `/events/2`, etc.)

Proper ordering at the bottom of the events page
![screen shot 2015-04-02 at 1 01 39 am](https://cloud.githubusercontent.com/assets/2433509/6958572/fd235b8e-d8db-11e4-9997-47848e5354c5.png)

No events this week
![screen shot 2015-04-02 at 1 54 56 am](https://cloud.githubusercontent.com/assets/2433509/6958577/fd25c234-d8db-11e4-996e-4e88aa773a77.png)

No events upcoming
![screen shot 2015-04-02 at 1 55 11 am](https://cloud.githubusercontent.com/assets/2433509/6958576/fd257a7c-d8db-11e4-96ad-8cdf587719b8.png)

Neither events this week or upcoming events
![screen shot 2015-04-02 at 1 01 33 am](https://cloud.githubusercontent.com/assets/2433509/6958573/fd23bcb4-d8db-11e4-8137-88f910f3e7f5.png)

Events from the bottom of `/events` don't show up in the archive (see first screenshot to compare)
![screen shot 2015-04-02 at 1 01 48 am](https://cloud.githubusercontent.com/assets/2433509/6958575/fd24ff48-d8db-11e4-91c9-1ac6bc576a04.png)
