### PR TITLE
Skip google calendar api calls when GOOGLE_AUTH_ENABLED=FALSE

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,16 +43,20 @@ def create_app(**config_overrides):
 
     # Initialize the Google Calendar API Client, but only if the api
     # credentials have been generated first.
-    if app.config.get('GOOGLE_AUTH_ENABLED'):
-        try:
-            from app.lib.google_calendar import GoogleCalendarAPIClient
-            gcal_client = GoogleCalendarAPIClient()
-        except IOError:
-            print ("Failed to find the Google Calendar credentials file at '{}', "
-                   'please create it by running:\n\n'
-                   '    $ python manage.py --authorize\n'
-                    .format(app.config['INSTALLED_APP_CREDENTIALS_PATH']))
-            exit(1)
+    try:
+        from app.lib.google_calendar import GoogleCalendarAPIClient
+        gcal_client = GoogleCalendarAPIClient()
+    except IOError:
+        gae_environ = 'TRUE' if app.config['GOOGLE_AUTH_ENABLED'] else 'FALSE'
+        print ('Failed to find the Google Calendar credentials file at `{}`, '
+               'please create it by running:\n\n'
+               '    $ python manage.py --authorize\n'
+               'The environment variable GOOGLE_AUTH_ENABLED is currently set '
+               'to `{}`.  If set to FALSE, Google Calendar calls will fail '
+               'silently.'
+               .format(app.config['INSTALLED_APP_CREDENTIALS_PATH'],
+                       gae_environ))
+        exit(1)
 
     register_blueprints()
     register_delete_rules()

--- a/app/lib/decorators.py
+++ b/app/lib/decorators.py
@@ -154,8 +154,6 @@ class skip_and_return_if(object):
             :param args: Arguments for ``f``.
             :params kwargs: Keyword arguments for ``f``.
             """
-            print app.config['GOOGLE_AUTH_ENABLED']
-            print self.flag
             if self.flag:
                 return None
             return f(*args, **kwargs)

--- a/app/lib/decorators.py
+++ b/app/lib/decorators.py
@@ -9,6 +9,7 @@ from app import app
 from flask import url_for, redirect, session, request, g, abort
 from functools import wraps
 
+
 def login_required(f):
     """A decorator requiring a user to be logged in.  Use this to decorate
     routes that require a user logged into Eventum to access.
@@ -21,6 +22,7 @@ def login_required(f):
     :rtype: func
     """
     from app.routes.base import lookup_current_user
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """The decorated version of ``f`` (see :method:``login_required``).
@@ -59,8 +61,8 @@ class requires_privilege(object):
         """Create a decorator to limit access to a decorated function to the
         secified privileges.
 
-        :param str privilege: The privilege that the logged in user should have.
-        It can be either ``"edit"``, ``"publish"``, or ``"admin"``.
+        :param str privilege: The privilege that the logged in user should
+        have. It can be either ``"edit"``, ``"publish"``, or ``"admin"``.
         """
         self.privilege = privilege
 
@@ -116,3 +118,45 @@ def development_only(f):
         return f(*args, **kwargs)
 
     return decorated_function
+
+
+class skip_and_return_if(object):
+    """A decorator that will skip the wrapped function and automatically return
+    ``None`` if the passed ``flag`` is ``True``.
+
+    Decorators like this that take parameters themselves must be
+    implemented either as a three nested functions (ugly), or as a class
+    (this implementation).  The ``__init__`` method creates the decorator,
+    and is passed any arguments for how the decorator should behaive, and
+    then the ``__call__`` method
+    """
+
+    def __init__(self, flag):
+        """Create a decorator to skip the decorated function and return
+        ``None`` if ``flag`` is ``True``.
+
+        :param bool flag: Skip the decorated function if this is ``True``.
+        """
+        self.flag = flag
+
+    def __call__(self, f):
+        """Call the decorator, on the decorated function, ``f``.
+
+        :param func f: The decorated function.
+        :returns: The parameter function ``f``, modified to short curcuit to
+        ``None`` if self.flag is true.
+        :rtype: func
+        """
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            """The decorated version of ``f`` (see :method:``__call__``).
+
+            :param args: Arguments for ``f``.
+            :params kwargs: Keyword arguments for ``f``.
+            """
+            print app.config['GOOGLE_AUTH_ENABLED']
+            print self.flag
+            if self.flag:
+                return None
+            return f(*args, **kwargs)
+        return decorated_function

--- a/app/lib/google_calendar.py
+++ b/app/lib/google_calendar.py
@@ -5,14 +5,17 @@ from apiclient.discovery import build
 from apiclient.errors import HttpError
 from oauth2client.file import Storage
 
+from app import app
+from app.models import Event
 from app.lib.google_calendar_resource_builder import GoogleCalendarResourceBuilder
+from app.lib.decorators import skip_and_return_if
 from app.lib.error import (GoogleCalendarAPIError,
                            GoogleCalendarAPIMissingID,
                            GoogleCalendarAPIBadStatusLine,
                            GoogleCalendarAPIEventAlreadyDeleted,
                            GoogleCalendarAPIErrorNotFound)
-from app import app
-from app.models import Event
+
+from config.flask_config import GOOGLE_AUTH_ENABLED
 
 
 class GoogleCalendarAPIClient():
@@ -46,6 +49,7 @@ class GoogleCalendarAPIClient():
             return self.public_calendar_id
         return self.private_calendar_id
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def _get_service(self):
         """Create and return the Google Calendar service object, using the
         credentials file generated through the command::
@@ -73,6 +77,7 @@ class GoogleCalendarAPIClient():
 
         return build('calendar', 'v3', http=http)
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def create_event(self, event):
         """Creates the event in Google Calendar.
 
@@ -104,6 +109,7 @@ class GoogleCalendarAPIClient():
         # Return the Google Calendar response dict
         return created_event
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def update_event(self, stale_event, as_exception=False):
         """Updates the event in Google Calendar.
 
@@ -177,6 +183,7 @@ class GoogleCalendarAPIClient():
         # Return the Google Calendar response dict
         return updated_event
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def publish_event(self, stale_event):
         """Publish an event, moving it to the public calendar.
 
@@ -205,6 +212,7 @@ class GoogleCalendarAPIClient():
         return self.move_event(event, from_id=self.private_calendar_id,
                                to_id=self.public_calendar_id)
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def unpublish_event(self, stale_event):
         """Unpublish an event, moving it to the private calendar.
 
@@ -233,6 +241,7 @@ class GoogleCalendarAPIClient():
         return self.move_event(event, from_id=self.public_calendar_id,
                                to_id=self.private_calendar_id)
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def move_event(self, event, from_id, to_id):
         """Move an event between calendars.
 
@@ -264,6 +273,7 @@ class GoogleCalendarAPIClient():
             app.logger.warning('[GOOGLE_CALENDAR]: ' + message)
             raise GoogleCalendarAPIErrorNotFound(message, uri=e.uri)
 
+    @skip_and_return_if(not GOOGLE_AUTH_ENABLED)
     def delete_event(self, event, as_exception=False):
         """Delete an event or series from Google Calendar, or cancel a single
         event from a series.

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -14,7 +14,6 @@ Werkzeug==0.9.4
 argparse==1.2.1
 blinker==1.3
 coverage==3.7.1
-## FIXME: could not find svn URL in dependency_links for this package:
 docutils==0.12
 flake8==2.2.5
 flask-mongoengine==0.7.0
@@ -26,9 +25,12 @@ mccabe==0.2.1
 misaka==1.0.2
 mongoengine==0.8.7
 pep8==1.5.7
+pyRFC3339==0.2
 pycurl==7.19.0
 pyflakes==0.8.1
 pymongo==2.7.2
+python-gflags==2.0
+pytz==2015.2
 requests==2.3.0
 webassets==0.8
 wsgiref==0.1.2


### PR DESCRIPTION
closes #155 

Right now, we only create `gcal_client` if the `GOOGLE_AUTH_ENABLED` environment variable is set to `TRUE`. Because of this, every create, update, and delete of events in development cause a 500 error.

To solve the problem, I  `gcal_client` either way, and then wrap all API calls in a decorator that will skip the call and return `None` if `GOOGLE_AUTH_ENABLED` is `False`.

I also updated `requirements.txt`.