### PR TITLE
fix wonky navbar on chrome mobile

### DIFF
--- a/app/static/scss/admin/navbar.scss
+++ b/app/static/scss/admin/navbar.scss
@@ -13,7 +13,7 @@ nav {
     position: fixed;
     left: 0;
     top: 0;
-    bottom: 0;
+    height: 100%;
     background-color: $darkgray;
     color: $white;
     @include transition(0.2s);


### PR DESCRIPTION
Review: @eunicekokor @RaymondXu 

Closes #175 

Essentially, when we have `bottom: 0` and `top:0` on a fixed position element (the drawer, in this case), it waits for the search box to animate away before redrawing.  When we just have `top:0`, it defaults to obeying that rule, and then the `height: 100%` of the element is what updates late (see screenshot, in which I am mid-scroll, holding my finger on the screen). 

I think that this is a much better compromise here, because the weirdness only occurs when the drawer is open and you scroll the window.

We could further solve this by disallowing scrolling of the page while the drawer is open, but I'll make that a separate issue.

![2015-04-14 04 05 00](https://cloud.githubusercontent.com/assets/2433509/7130223/2bef77e2-e23a-11e4-94bb-2c04ab28800a.png)