### PR TITLE
Write deploy script to swap docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,5 @@ WORKDIR /
 # expose the port and start the server
 EXPOSE 6000
 
-CMD cd docs && make html && cd ..
+CMD gunicorn run:app -b 0.0.0.0:6000 --log-file /opt/logs/gunicorn.log --log-level debug
 
-CMD gunicorn deploy:app -b 0.0.0.0:6000 --log-file /opt/logs/gunicorn.log --log-level debug

--- a/deploy.py
+++ b/deploy.py
@@ -1,7 +1,0 @@
-from app import create_app
-
-app = create_app()
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
-

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,6 +52,7 @@ fi
 docker build -t $NEW_NAME .
 
 # --net: Use the local network stack
+# --restart: Always restart, even if it crashes
 # -v: mount a volume, to ensure that created or edited files are not sandboxed
 #     to the server (one for logs, one for images)
 # -d: detach after running, instead of entering the container
@@ -59,6 +60,7 @@ docker build -t $NEW_NAME .
 
 docker run \
     --net=host \
+    --restart=always \
     -v $ADI_WWW/../logs:/opt/logs \
     -v $ADI_WWW/app/static/img/uploaded:/app/static/img/uploaded \
     -d \

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,6 +27,11 @@ else
     exit
 fi
 
+# Validate nginx configurations
+if [ ! nginx -t ]; then
+    echo "Nginx config failed!"
+    exit
+fi
 
 # Determine the new and old container names
 NEW_NAME=""

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,6 +50,13 @@ fi
 
 # Startup the new container
 docker build -t $NEW_NAME .
+
+# --net: Use the local network stack
+# -v: mount a volume, to ensure that created or edited files are not sandboxed
+#     to the server (one for logs, one for images)
+# -d: detach after running, instead of entering the container
+# --name: Set the name of the container
+
 docker run \
     --net=host \
     -v $ADI_WWW/../logs:/opt/logs \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+NGINX_CONFIG=/etc/nginx/sites-available/adi-website
+ADI_WWWW=/srv/adi-website/www
+DOCKERFILE=Dockerfile
+PORT1=7000
+PORT2=6000
+IMAGE_NAME=adi-website
+NAME1="adi-website-1"
+NAME2="adi-website-2"
+
+
+if [ ! -e "$NGINX_CONFIG" ]; then
+    echo "Cannot find file $NGINX_CONFIG. Are you running this on the server?"
+    exit
+fi
+
+# Swap the port in nginx and in the Dockerfile
+PORT="$(cat $NGINX_CONFIG | grep 'set \$ADI_WEBSITE_PORT' | grep -o '[0-9]*')"
+if [ $PORT -eq $PORT1 ]; then
+    sed -i "s/$PORT1/$PORT2/g" $NGINX_CONFIG
+    sed -i "s/$PORT1/$PORT2/g" $DOCKERFILE
+elif [ $PORT -eq $PORT2 ]; then
+    sed -i "s/$PORT2/$PORT1/g" $NGINX_CONFIG
+    sed -i "s/$PORT2/$PORT1/g" $DOCKERFILE
+else
+    echo "adi-website running on unknown port: $PORT"
+    exit
+fi
+
+
+# Determine the new and old container names
+NEW_NAME=""
+OLD_NAME=""
+CURRENT_NAME="$(docker ps -a | grep adi-website: | awk 'NF>1{print $NF}')"
+if [ "$CURRENT_NAME" == "$NAME1" ]; then
+    OLD_NAME=$NAME1
+    NEW_NAME=$NAME2
+elif [ "$CURRENT_NAME" == "$NAME2" ]; then
+    OLD_NAME=$NAME2
+    NEW_NAME=$NAME1
+else
+    echo "Docker Image has unknown name $CURRENT_NAME"
+    exit
+fi
+
+# Startup the new container
+docker build -t $NEW_NAME .
+docker run \
+    --net=host \
+    -v $ADI_WWW/../logs:/opt/logs \
+    -v $ADI_WWW/app/static/img/uploaded:/app/static/img/uploaded \
+    -d \
+    --name="$NEW_NAME" $NEW_NAME
+
+# swap to the new container
+sudo service nginx restart
+
+# Kill the old container
+docker kill $OLD_NAME
+docker rm $OLD_NAME

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,6 @@ ADI_WWWW=/srv/adi-website/www
 DOCKERFILE=Dockerfile
 PORT1=7000
 PORT2=6000
-IMAGE_NAME=adi-website
 NAME1="adi-website-1"
 NAME2="adi-website-2"
 
@@ -32,7 +31,7 @@ fi
 # Determine the new and old container names
 NEW_NAME=""
 OLD_NAME=""
-CURRENT_NAME="$(docker ps -a | grep adi-website: | awk 'NF>1{print $NF}')"
+CURRENT_NAME="$(docker ps -a | grep adi-website | awk 'NF>1{print $NF}')"
 if [ "$CURRENT_NAME" == "$NAME1" ]; then
     OLD_NAME=$NAME1
     NEW_NAME=$NAME2


### PR DESCRIPTION
Review: @natebrennand @thebrianzeng 

- delete `deploy.py`, and use `run.py` instead.  There's no difference, because gunicorn doesn't run `deploy.py` as a script, so the contents of the `if __name__ == '__main__':` block is irrelevant
- Write `deploy.sh` which swaps between two configurations for ports and docker containers