### PR TITLE
Styling

### DIFF
--- a/app/static/scss/client/base.scss
+++ b/app/static/scss/client/base.scss
@@ -27,6 +27,7 @@ pre {
     padding: 1rem;
     background-color: $codebackground;
     font-family: monospace;
+    overflow: scroll;
 }
 
 ul li {

--- a/app/static/scss/client/blog/post.scss
+++ b/app/static/scss/client/blog/post.scss
@@ -29,4 +29,8 @@
         margin-bottom: 1rem;
         line-height: 1.9rem;
     }
+    ul {
+        list-style-type: circle;
+        margin: 1.75rem;
+    }
 }

--- a/app/static/scss/client/single_event/single_event.scss
+++ b/app/static/scss/client/single_event/single_event.scss
@@ -5,6 +5,19 @@
 .single-event {
     .text {
         margin-left: 33%;
+
+        ol {
+            list-style: initial;
+            list-style-type: decimal;
+            font-size: 1.2rem;
+            margin-left: 2rem;
+            margin-bottom: 1rem;
+            line-height: 1.9rem;
+        }
+        ul {
+            list-style-type: circle;
+            margin: 1.75rem;
+        }
     }
 
     .details {


### PR DESCRIPTION
![screen shot 2015-05-01 at 4 29 56 pm](https://cloud.githubusercontent.com/assets/7966567/7436829/594abc7c-f01f-11e4-94a8-b35077a685fd.png)

![screen shot 2015-05-01 at 4 32 21 pm](https://cloud.githubusercontent.com/assets/7966567/7436881/cc80d6e0-f01f-11e4-9ae2-e4cbc2f1fe0c.png)

Not sure yet how to enable syntax highlighting in events, but the blog post `<ul>` style has been applied, and the overflow in the code blocks for events has been set to scroll.
