### PR TITLE
Better gcal descriptions

### DIFF
--- a/app/lib/google_calendar_resource_builder.py
+++ b/app/lib/google_calendar_resource_builder.py
@@ -1,6 +1,6 @@
 from pyrfc3339 import generate
 import pytz
-import re
+from app.lib.text import clean_markdown
 from app.lib.error import GoogleCalendarAPIError
 
 
@@ -28,7 +28,9 @@ class GoogleCalendarResourceBuilder():
         resource = {}
         resource['summary'] = event.title
         resource['location'] = event.location
-        resource['description'] = cls._strip_tags(event.long_description)
+        resource['description'] = clean_markdown(
+            event.long_description_markdown
+        )
         resource['status'] = 'confirmed' if event.published else 'tentative'
         if for_update:
             resource['sequence'] = event.gcal_sequence + 1
@@ -90,19 +92,6 @@ class GoogleCalendarResourceBuilder():
         """
         d = s.recurrence_end_date
         return '%d%02d%02dT235959Z' % (d.year, d.month, d.day)
-
-    @classmethod
-    def _strip_tags(cls, html):
-        """Strips the tags out of ``html``
-
-        :param str html: The HTML string to clean
-
-        :returns: The cleaned string
-        :rtype: str
-        """
-
-        p = re.compile(r'<.*?>')
-        return p.sub(' ', html)
 
     @classmethod
     def rfc3339(cls, datetime):

--- a/app/lib/text.py
+++ b/app/lib/text.py
@@ -2,7 +2,7 @@ import re
 
 
 def truncate_html(text, truncate_len, truncate_text):
-    """ Truncates HTML to a certain number of words (not counting tags and
+    """Truncates HTML to a certain number of words (not counting tags and
     comments). Closes opened tags if they were correctly closed in the given
     HTML. If text is truncated, truncate_text will be appended to the result.
 
@@ -84,3 +84,36 @@ def truncate_html(text, truncate_len, truncate_text):
         out += '</{}>'.format(tag)
     # Return string
     return out
+
+
+def clean_markdown(markdown):
+    """Formats markdown text for easier plaintext viewing.  Performs the
+    following substitutions:
+
+    - Removes bad or empty links
+    - Removes images
+    - Formats hyperlinks from ``[link](http://adicu.com)`` to
+    ``link (http://adicu.com)``.
+
+    :param str markdown: The markdown text to format.
+
+    :returns: the formatted text:
+    :rtype: str
+    """
+    substitutions = [
+        # Remove images: '\t   ![hello](anything)' -> ''
+        (r'\s*\!\[[^\]]*\]\([^\)]*\)', r''),
+        # Remove empty links: '\t   [\t   ](anything)' -> ''
+        (r'\s*\[\s*\]\([^\)]*\)', r''),
+        # Links: '[hello](http://google.com)' -> 'hello (http://google.com)'
+        (r'\[(?P<text>.*)\]\((?P<link>http[s]?://[^\)]*)\)', r'\1 (\2)'),
+        # Bad links: '[hello](garbage)' -> 'hello'
+        (r'\[(?P<text>.*)\]\((?P<link>[^\)]*)\)', r'\1'),
+        # Remove italics / bold: '*' -> ''
+        (r'\*', r''),
+    ]
+
+    for pattern, repl in substitutions:
+        markdown = re.sub(pattern, repl, markdown)
+
+    return markdown

--- a/test/test_lib/test_text.py
+++ b/test/test_lib/test_text.py
@@ -1,0 +1,32 @@
+"""
+.. module:: test_text
+    :synopsis: Tests for the :mod:`~app.lib.text` module.
+
+.. moduleauthor:: Dan Schlosser <dan@danrs.ch>
+"""
+from test.base import TestingTemplate
+from app.lib.text import clean_markdown
+
+
+class TestTextHelpers(TestingTemplate):
+    """Test the date, time, and datetime formatting in the Event model."""
+
+    ERROR_MSG = 'Incorrect:\nexpected: "{}"\n     got: "{}"'
+
+    MARKDOWN_EXPECTATIONS = [
+        ('An [](http://empty-link).', 'An.'),
+        ('A [test](https://adicu.com)', 'A test (https://adicu.com)'),
+        ('A [test](http://adicu.com)', 'A test (http://adicu.com)'),
+        ('A [test](garbage) passes.', 'A test passes.'),
+        ('An ![image](http://anything) gets removed.', 'An gets removed.'),
+        ('An ![image](garbage), [link](http://adicu.com), and an '
+         '[![image in a link](imgurl)](http://adicu.com).',
+         'An, link (http://adicu.com), and an.'),
+    ]
+
+    def test_clean_markdown(self):
+        for md_in, md_out in self.MARKDOWN_EXPECTATIONS:
+            output = clean_markdown(md_in)
+            self.assertEqual(output,
+                             md_out,
+                             msg=self.ERROR_MSG.format(md_out, output))

--- a/test/test_lib/test_text.py
+++ b/test/test_lib/test_text.py
@@ -14,6 +14,8 @@ class TestTextHelpers(TestingTemplate):
     ERROR_MSG = 'Incorrect:\nexpected: "{}"\n     got: "{}"'
 
     MARKDOWN_EXPECTATIONS = [
+        ('**Bold** text is unbolded.', 'Bold text is unbolded.'),
+        ('So is *underlined* text.', 'So is underlined text.'),
         ('An [](http://empty-link).', 'An.'),
         ('A [test](https://adicu.com)', 'A test (https://adicu.com)'),
         ('A [test](http://adicu.com)', 'A test (http://adicu.com)'),


### PR DESCRIPTION
Review: @natebrennand @eunicekokor @RaymondXu 

Closes #112 by writing a method `clean_markdown` in `app/lib/text.py` that cleans up markdown text for better viewing.

- Removes bad or empty links
- Removes images
- Formats hyperlinks from ``[link](http://adicu.com)`` to ``link (http://adicu.com)``.

There are tests :)