### PR TITLE
Table based error handling

### DIFF
--- a/app/lib/error.py
+++ b/app/lib/error.py
@@ -1,45 +1,251 @@
 """
 .. module:: error
-    :synopsis: Errors to be raised in the app.
+    :synopsis: Home to the :class:`EventumError` class, which contains
+        namespaced subclasses that should be used when raising and handling
+        exceptions in eventum.
 
 .. moduleauthor:: Dan Schlosser <dan@danrs.ch>
+
+This module is slightly complicated.  It contains three main components: the
+nested dictionary ``ERROR_DATA``, the class :class:`EventumError`, and the
+function :func:`_make_subclasses`.  The dictionary ``ERROR_DATA`` contains a
+family tree of subclasses for :class:`EventumError`. Each key is an error name,
+and the value is a four-tuple of::
+
+    (message, error_code, http_status_code, subclasses)
+
+The ``message`` is a string that may be shown to users, in the app, and logged
+to the application logs.
+
+The ``error_code`` is a namespaced, unique number that can be easily used to
+identify error messages in other parts of the app, or in JavaScript. They are
+namespaced.  For example, Google Calendar API errors have error code ``6XX``,
+and Google Calendar Not Found errors are ``64X``.
+
+The ``http_status_code`` is the HTTP status code that should be associated with
+this error should it reach the user.
+
+The ``subclasses`` entry is a dictionary of similar structure, containing
+recurisve error subclasses of this error.
+
+In order to add a new error, simply add a new entry to the ERROR_DATA
+dictionary at the proper level of indentation.  Related errors should share
+common superclasses, and have similar ``error_code`` values.
+
+Example usage::
+
+
+    from app.lib.error import EventumError
+    # ...
+    try:
+        raise EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
+    except EventumError.GCalAPI.NotFound.UpdateFellBackToCreate:
+        # handle error...
+
+However, we can also except multiple errors by excepting their common
+superclass::
+
+
+    from app.lib.error import EventumError
+    # ...
+    try:
+        if something():
+            raise EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
+        elif something_else():
+            raise EventumError.GCalAPI.BadStatusLine()
+        else:
+            raise EventumError.GCAlAPI():
+    except EventumError.GCalAPI:
+        # handles all above errors.
+
 """
 
+import re
+from new import classobj
+from app import app
 
-class GoogleCalendarAPIError(Exception):
-    """Something went wrong with Google Calendar."""
-    DEFAULT_MESSAGE = 'Something went wrong with Google Calendar.'
+HTTP_OK = 200
+HTTP_BAD_REQUEST = 400
+HTTP_INTERNAL_SERVER_ERROR = 500
 
-    def __init__(self, message=None):
-        if not message:
-            message = self.DEFAULT_MESSAGE
-        Exception.__init__(self, message)
+# Dictionary of:
+# {ErrorName: (message, error_code, http_status_code, error_subclasses)}
+ERROR_DATA = {
+
+    ###################################
+    # 6XX: Google Calendar API Errors #
+    ###################################
+    'GCalAPI': (
+        'Something went wrong with Google Calendar.',
+        600, HTTP_INTERNAL_SERVER_ERROR, {
+
+            'MissingID': (
+                'This event was not assigned a gcal_id.',
+                610, HTTP_INTERNAL_SERVER_ERROR, {
+
+                    'FellBackToCreate': (
+                        'Missing gplus_id. Successfully fell back to create.',
+                        611, HTTP_OK, {}),
+                }),
+
+            'BadStatusLine': (
+                'Encountered a Bad Status Line error with the API',
+                620, HTTP_INTERNAL_SERVER_ERROR, {}),
+
+            'EventAlreadyDeleted': (
+                'Encountered a Bad Status Line error with the API',
+                630, HTTP_INTERNAL_SERVER_ERROR, {}),
+
+            'NotFound': (
+                'Got "Not Found" from Google Calendar.',
+                640, HTTP_INTERNAL_SERVER_ERROR, {
+
+                    'UpdateFellBackToCreate': (
+                        'Couldn\'t find an event to update. Successfully fell '
+                        'back to create.',
+                        641, HTTP_OK, {}),
+
+                    'MoveFellBackToCreate': (
+                        'Couldn\'t find an event to move. Successfully fell '
+                        'back to create.',
+                        642, HTTP_OK, {}),
+                }),
+
+            'PublishFailed': (
+                'Failed to Publish Event',
+                650, HTTP_INTERNAL_SERVER_ERROR, {
+
+                    'PublishedFalse': (
+                        'Event must have the `published` set to `True` '
+                        ' before publishing.',
+                        651, HTTP_INTERNAL_SERVER_ERROR, {}),
+
+                    'PublishedTrue': (
+                        'Event must have the `published` set to `True` '
+                        ' before unpublishing.',
+                        652, HTTP_INTERNAL_SERVER_ERROR, {}),
+                }),
+
+            'EventMustEndOnOrAfter': (
+                'A series should either end on a specific date, or after a '
+                'specific number of occurences.  Series.ends_on and ends_after'
+                ' are both false.',
+                660, HTTP_BAD_REQUEST, {})
+        }),
+}
 
 
-class GoogleCalendarAPIMissingID(GoogleCalendarAPIError):
-    """This event was not assigned a gcal_id"""
+class EventumError(Exception):
+    """The base error class for Eventum.  All errors are subclasses of
+    :class:`EventumError`.
+    """
 
-    DEFAULT_MESSAGE = 'This event was not assigned a gcal_id'
+    message = 'An error occurred.'
+    error_code = 0
+    http_status_code = HTTP_INTERNAL_SERVER_ERROR
+
+    def __init__(self, *subs, **kwargs):
+        """Called to create an instance of :class:`EventumError`.  Subclasses
+        of :class:`EventumError` inherit this method.  It uses ``subs`` to
+        populate any format strings in the class's error message, and saves
+        any kwargs as data attributes to be associate with the request.
+
+        Initializing a subclass of EventumError will also log to the app log.
+
+        :param subs: Strings to subsitute into the format string for the error
+            message associated with class.
+        :type subs: list(str)
+        :param dict kwargs: any arbitrary data that should be logged along with
+            this error.
+        """
+        self.data = kwargs
+        self.error_type = self.__class__.__name__
+        self.message = self._form_message(self.message, subs)
+        self.log_error()
+
+    def log_error(self):
+        """Print the error type and plaintext message to the warning logs,
+        as well as any other data associated with it.
+        """
+        message = '[{}]: {}'.format(self.error_type, self.message)
+        app.logger.warning(message)
+        if self.data:
+            app.logger.warning('[{}][DATA]: {}'.format(self.error_type,
+                                                       self.data))
+
+    def _form_message(self, message, subs):
+        """Apply subsitutions to the error message if any exist.  If there are
+        spots for subsitutions variables in the error message (if the strings
+        ``'%s'`` appears anywhere in the string) and there are not enough
+        strings in ``subs`` to fill them, instances of ``'%s'`` will be removed
+        from the error message.  If there are two many strings in ``subs``,
+        later strings will be ignored.
+
+        Here are some examples::
+
+            >>> _form_message('Error at url `%s`: %s', ['/home', 'Not Found'])
+            'Error at url `/home`: Not Found'
+            >>> _form_message('Error at url `%s`: %s', ['/home'])
+            'Error at url `/home`: '
+            >>> _form_message('Error at url.', ['/home'])
+            'Error at url.'
+
+        :param str message: The format string to format.
+        :param subs: The strings to subsitute into the format string.
+        :type subs: list(str)
+
+        :returns: The formatted string.
+        :rtype: str
+        """
+        n_subs = message.count('%s')
+
+        # Extend subs if there aren't enough
+        if n_subs > len(subs):
+            subs.extend([''] * (n_subs - len(subs)))
+
+        # Shorten subs if there are too many
+        if len(subs) > n_subs:
+            subs = subs[:n_subs]
+
+        # Perform substitutions
+        if subs:
+            message = message % subs
+
+        return re.sub(r'\%s', '', message)
 
 
-class GoogleCalendarAPIBadStatusLine(GoogleCalendarAPIError):
-    """Encountered a Bad Status Line error with the API"""
+def _make_subclasses(error_data, baseclass):
+    """Recursively add subclass errors to ``baseclass``.
 
-    DEFAULT_MESSAGE = 'Encountered a Bad Status Line error with the API'
+    :param dict error_data: A dictionary of error name strings to a four-tuple
+        of ``(message, error_code, http_status_code, subclasses)``. The
+        ``message`` is the user-facing message to display, the ``error_code``
+        is a unique number representing the error, the ``http_status_code`` is
+        the HTTP status code that should be associated with this error should
+        it surface to the user, and subcalsses is a dictionary of this same
+        type, containing data for subclasses of this error.
+    :param baseclass: The error class to attach these errors onto.
+    :type baseclass: :class:`EventumError` or one of its subclasses.
+    """
+    if not error_data:
+        return
 
+    for e_type, e_attrs in error_data.iteritems():
+        # Make the new class object
+        name = '{}.{}'.format(baseclass.__name__, e_type)
+        subclass = classobj(name, (baseclass,), {})
 
-class GoogleCalendarAPIEventAlreadyDeleted(GoogleCalendarAPIError):
-    """Encountered a Bad Status Line error with the API"""
+        # Configure it's message, error_code, and http_status_code
+        subclass.message = e_attrs[0]
+        subclass.error_code = e_attrs[1]
+        subclass.http_status_code = e_attrs[2]
 
-    DEFAULT_MESSAGE = 'This event was deleted from Google Calendar'
+        # Recursively generate subclasses
+        _make_subclasses(e_attrs[3], subclass)
 
+        # Add this subclass as an attribute of the baseclass
+        setattr(EventumError, e_type, subclass)
 
-class GoogleCalendarAPIErrorNotFound(GoogleCalendarAPIError):
-    """Got 'Not Found' from Google Calendar"""
-
-    DEFAULT_MESSAGE = "Got 'Not Found' from Google Calendar: "
-
-    def __init__(self, uri, message=None):
-        if not message:
-            message = self.DEFAULT_MESSAGE + uri
-        GoogleCalendarAPIError.__init__(self, message=message)
+# Start the recurisve generation of EventumError subclasses.  This code gets
+# run whenever the module is imported.
+_make_subclasses(ERROR_DATA, EventumError)

--- a/app/lib/error.py
+++ b/app/lib/error.py
@@ -7,8 +7,8 @@
 .. moduleauthor:: Dan Schlosser <dan@danrs.ch>
 
 This module is slightly complicated.  It contains three main components: the
-nested dictionary ``ERROR_DATA``, the class :class:`EventumError`, and the
-function :func:`_make_subclasses`.  The dictionary ``ERROR_DATA`` contains a
+nested dictionary ``_ERROR_DATA``, the class :class:`EventumError`, and the
+function :func:`_make_subclasses`.  The dictionary ``_ERROR_DATA`` contains a
 family tree of subclasses for :class:`EventumError`. Each key is an error name,
 and the value is a four-tuple of::
 
@@ -28,7 +28,7 @@ this error should it reach the user.
 The ``subclasses`` entry is a dictionary of similar structure, containing
 recurisve error subclasses of this error.
 
-In order to add a new error, simply add a new entry to the ERROR_DATA
+In order to add a new error, simply add a new entry to the _ERROR_DATA
 dictionary at the proper level of indentation.  Related errors should share
 common baseclasses, and have similar ``error_code`` values.
 
@@ -68,7 +68,7 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 
 # Dictionary of:
 # {ErrorName: (message, error_code, http_status_code, error_subclasses)}
-ERROR_DATA = {
+_ERROR_DATA = {
 
     ###################################
     # 6XX: Google Calendar API Errors #
@@ -249,7 +249,7 @@ def _make_subclasses(error_data, baseclass):
         # We then create a class dynamically, using `type()`.
         # Arguments are:
         #    name: the name of the class
-        #    (baseclass,): a tuple of baseclasse
+        #    (baseclass,): a tuple of baseclasses
         #    {}: a namespace of function definitions (we don't need any)
         subclass = type(name, (baseclass,), {})
 
@@ -266,6 +266,6 @@ def _make_subclasses(error_data, baseclass):
         # Add this subclass as an attribute of the baseclass
         setattr(EventumError, e_type, subclass)
 
-# Start the recurisve generation of EventumError subclasses.  This code gets
+# Start the recursive generation of EventumError subclasses.  This code gets
 # run whenever the module is imported.
-_make_subclasses(ERROR_DATA, EventumError)
+_make_subclasses(_ERROR_DATA, EventumError)

--- a/app/lib/error.py
+++ b/app/lib/error.py
@@ -89,7 +89,8 @@ ERROR_DATA = {
                 }),
 
             'BadStatusLine': (
-                'Encountered a Bad Status Line error with the API',
+                'Encountered a BadStatusLine error with the Google Calendar '
+                'API.',
                 620, HTTP_INTERNAL_SERVER_ERROR, {}),
 
             'EventAlreadyDeleted': (
@@ -168,10 +169,10 @@ class EventumError(Exception):
         as well as any other data associated with it.
         """
         message = '[{}]: {}'.format(self.error_type, self.message)
-        app.logger.warning(message)
+        app.logger.error(message)
         if self.data:
-            app.logger.warning('[{}][DATA]: {}'.format(self.error_type,
-                                                       self.data))
+            app.logger.error('[{}][DATA]: {}'.format(self.error_type,
+                                                     self.data))
 
     def _form_message(self, message, subs):
         """Apply subsitutions to the error message if any exist.  If there are

--- a/app/lib/google_calendar_resource_builder.py
+++ b/app/lib/google_calendar_resource_builder.py
@@ -1,7 +1,7 @@
 from pyrfc3339 import generate
 import pytz
 from app.lib.text import clean_markdown
-from app.lib.error import GoogleCalendarAPIError
+from app.lib.error import EventumError
 
 
 class GoogleCalendarResourceBuilder():
@@ -19,7 +19,7 @@ class GoogleCalendarResourceBuilder():
             update Google Calendar (in which case an extra ``sequence`` field
             is required).
 
-        :raises: GoogleCalendarAPIError
+        :raises: :class:`EventumError.GCalAPI.EventMustEndOnOrAfter`
 
         :returns: An event resource
         :rtype: dict
@@ -72,11 +72,7 @@ class GoogleCalendarResourceBuilder():
         elif s.ends_after:
             r += ';COUNT=%d' % s.num_occurrences
         else:
-            raise GoogleCalendarAPIError(
-                'A series should either end on a specific date, or after a '
-                'specific number of occurences.  Series.ends_on and ends_after'
-                ' are both false.'
-            )
+            raise EventumError.GCalAPI.EventMustEndOnOrAfter()
         return r
 
     @classmethod

--- a/app/models/User.py
+++ b/app/models/User.py
@@ -119,7 +119,7 @@ class User(db.Document):
         if self.image:
             return self.image.url()
         if not self.image_url:
-            # import app in the function body to avoid importing `None` when
+            # Import app in the function body to avoid importing `None` when
             # the module is first loaded.
             from app import app
             return url_for('static',

--- a/app/routes/admin/events.py
+++ b/app/routes/admin/events.py
@@ -20,7 +20,7 @@ from app.forms import (CreateEventForm, EditEventForm, DeleteEventForm,
 from app.lib.decorators import login_required, requires_privilege
 from app.routes.base import ERROR_FLASH, MESSAGE_FLASH
 
-from app.lib.error import GoogleCalendarAPIError
+from app.lib.error import EventumError
 from app.lib.events import EventsHelper
 events = Blueprint('events', __name__)
 
@@ -134,7 +134,7 @@ def create():
     if form.validate_on_submit():
         try:
             EventsHelper.create_event(form, g.user)
-        except GoogleCalendarAPIError as e:
+        except EventumError.GCalAPI as e:
             flash(e.message, ERROR_FLASH)
 
         return redirect(url_for('.index'))
@@ -175,7 +175,7 @@ def edit(event_id):
     if form.validate_on_submit():
         try:
             EventsHelper.update_event(event, form)
-        except GoogleCalendarAPIError as e:
+        except EventumError.GCalAPI as e:
             flash(e.message, ERROR_FLASH)
 
         return redirect(url_for('.index'))
@@ -210,7 +210,7 @@ def delete(event_id):
         event = Event.objects().with_id(object_id)
         try:
             EventsHelper.delete_event(event, form)
-        except GoogleCalendarAPIError as e:
+        except EventumError.GCalAPI as e:
             flash(e.message, ERROR_FLASH)
     else:
         flash('Invalid event id', ERROR_FLASH)

--- a/develop.sh
+++ b/develop.sh
@@ -6,6 +6,7 @@ pip install -r config/requirements.txt
 consul agent \
     -server \
     -bootstrap \
-    -client 0.0.0.0 \
+    -advertise 127.0.0.1 \
+    -client 127.0.0.1 \
     -data-dir data/consul_data \
     -ui-dir /usr/share/consul/ui > log/consul.log &

--- a/test/test_lib/test_error.py
+++ b/test/test_lib/test_error.py
@@ -1,0 +1,70 @@
+"""
+.. module:: test_error
+    :synopsis: Tests for the :mod:`~app.lib.error` module.
+
+.. moduleauthor:: Dan Schlosser <dan@danrs.ch>
+"""
+from test.base import TestingTemplate
+from app.lib.error import EventumError, ERROR_DATA
+
+
+class TestErrorMethods(TestingTemplate):
+    """Test the date, time, and datetime formatting in the Event model."""
+
+    def setUp(self):  # noqa
+        """Disable logging, as we don't want logging to be outputted during
+        the tests.  Without this, any instantiations of EventumError subclasses
+        would log.
+        """
+        self.app.logger.disabled = True
+
+    def tearDown(self):  # noqa
+        """Re-enable logging."""
+        self.app.logger.propagate = False
+
+    def test_namespaced_error_is_properly_subclassed(self):
+        """An error should be a subclass of all of the errors that it is
+        namespaced underneath.
+        """
+        err = EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
+        err_class = err.__class__
+        self.assertTrue(issubclass(err_class, EventumError.GCalAPI.NotFound))
+        self.assertTrue(issubclass(err_class, EventumError.GCalAPI))
+        self.assertTrue(issubclass(err_class, EventumError))
+
+    def test_error_data_is_assigned(self):
+        """An error should have been assigned an appropriate ``message``,
+        ``error_code``, ``http_status_code``.
+        """
+        err = EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
+        message, error_code, http_status_code, _ = (
+            ERROR_DATA['GCalAPI'][3]['NotFound'][3]['UpdateFellBackToCreate']
+        )
+        self.assertEqual(err.message, message)
+        self.assertEqual(err.error_code, error_code)
+        self.assertEqual(err.http_status_code, http_status_code)
+
+    FORM_MESSAGE_MSG = ('EventumError._form_message() failed:\n'
+                        'expected: {}\n'
+                        '     got: {}\n')
+    FORM_MESSAGE_EXPECTATIONS = [
+        ('Error at url `%s`: %s', ('/home', 'Not Found'),
+         'Error at url `/home`: Not Found'),
+        ('Error at url `%s`: %s', ('/home',),
+         'Error at url `/home`: '),
+        ('Error at url.', ('/home',),
+         'Error at url.')
+
+    ]
+
+    def test_form_message(self):
+        """Test that :func:`EventumError._form_message()` returns the expected
+        output when given too few, too many, or the right number of subs.
+        """
+        error = EventumError()
+        for message, subs, expected_output in self.FORM_MESSAGE_EXPECTATIONS:
+            output = error._form_message(message, subs)
+            self.assertEqual(output,
+                             expected_output,
+                             msg=self.FORM_MESSAGE_MSG.format(expected_output,
+                                                              output))

--- a/test/test_lib/test_error.py
+++ b/test/test_lib/test_error.py
@@ -5,7 +5,7 @@
 .. moduleauthor:: Dan Schlosser <dan@danrs.ch>
 """
 from test.base import TestingTemplate
-from app.lib.error import EventumError, ERROR_DATA
+from app.lib.error import EventumError, _ERROR_DATA
 
 
 class TestErrorMethods(TestingTemplate):
@@ -38,7 +38,7 @@ class TestErrorMethods(TestingTemplate):
         """
         err = EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
         message, error_code, http_status_code, _ = (
-            ERROR_DATA['GCalAPI'][3]['NotFound'][3]['UpdateFellBackToCreate']
+            _ERROR_DATA['GCalAPI'][3]['NotFound'][3]['UpdateFellBackToCreate']
         )
         self.assertEqual(err.message, message)
         self.assertEqual(err.error_code, error_code)
@@ -54,7 +54,6 @@ class TestErrorMethods(TestingTemplate):
          'Error at url `/home`: '),
         ('Error at url.', ('/home',),
          'Error at url.')
-
     ]
 
     def test_form_message(self):


### PR DESCRIPTION
Review: @natebrennand @eunicekokor @evantarrh @RaymondXu 

Closes #191 

### Overview


This PR totally redoes errors for Eventum.  It makes it so that:
- Raising errors rarely involves writing string literals, and instead involves code like:

    ```python
    raise EventumError.GCalAPI.MissingID()
    ```
- Adding a new error involves adding a new entry to a dictionary, instead of writing and documenting a new class.
- errors are uniquely identifiable in JavaScript by an `error_code`
- errors are namespaced so that groups of similar errors can be handled together.
- errors can be passed arbitrary data to be logged
- errors can be customized with format strings.
- whenever an error is raised, it is also logged.

The solution uses a bit of python hacking (the use of recursion, `classobj()`, `setattr()`, etc in `error.py:_make_subclasses`), but it allows for the above.

### I would like specific input on

- Is this a worthwhile addition?
- How can it be more clear?
- Are there error handling features that should be added / removed to better fit our needs?
- Should there be tests associated with this PR?  What should they be?

### Details about implementation in `error.py`

This module is slightly complicated.  It contains three main components: the
nested dictionary ``ERROR_DATA``, the class `EventumError`, and the
function `_make_subclasses`.  The dictionary ``ERROR_DATA`` contains a
family tree of subclasses for `EventumError`. Each key is an error name,
and the value is a four-tuple of:

```python
(message, error_code, http_status_code, subclasses)
```

The ``message`` is a string that may be shown to users, in the app, and logged
to the application logs.

The ``error_code`` is a namespaced, unique number that can be easily used to
identify error messages in other parts of the app, or in JavaScript. They are
namespaced.  For example, Google Calendar API errors have error code ``6XX``,
and Google Calendar Not Found errors are ``64X``.

The ``http_status_code`` is the HTTP status code that should be associated with
this error should it reach the user.

The ``subclasses`` entry is a dictionary of similar structure, containing
recurisve error subclasses of this error.

In order to add a new error, simply add a new entry to the ERROR_DATA
dictionary at the proper level of indentation.  Related errors should share
common superclasses, and have similar ``error_code`` values.

Example usage:

```python
from app.lib.error import EventumError
# ...
try:
    raise EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
except EventumError.GCalAPI.NotFound.UpdateFellBackToCreate:
    # handle error...
```

However, we can also except multiple errors by excepting their common
superclass:

```python
from app.lib.error import EventumError
# ...
try:
    if something():
        raise EventumError.GCalAPI.NotFound.UpdateFellBackToCreate()
    elif something_else():
        raise EventumError.GCalAPI.BadStatusLine()
    else:
        raise EventumError.GCAlAPI()
except EventumError.GCalAPI:
    # handles all above errors.
```