### PR TITLE
Fix deploy script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN gem install sass
 COPY ./config/requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt
 
-ADD ./ /app
-WORKDIR /app
+ADD ./ /deploy
+WORKDIR /deploy
 
 EXPOSE 8181
-CMD source /app/config/secrets.prod && \
+CMD source /deploy/config/secrets.prod && \
         gunicorn run:app -b 0.0.0.0:8181

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 ADI_WWWW=/srv/adi-website/www
+BASE=/deploy
 DOCKERFILE=Dockerfile
 NAME="adi-website"
 
@@ -15,15 +16,13 @@ docker build -t $NAME .
 # --restart: Always restart, even if it crashes
 # -v: mount a volume, to ensure that edited log files live on the server,
 #     not in the docker box.
-# --volumes-from: Mount the uploaded images filesystem, so that new image
-#                 live on the server, not in the docker box.
 # -d: detach after running, instead of entering the container
 # --name: Set the name of the container
 
 docker run \
     --net=host \
     --restart=always \
-    -v $ADI_WWWW/../logs:/logs \
-    -v $ADI_WWWW/app/static/img/uploaded:/app/static/img/uploaded \
+    -v $ADI_WWWW/../logs:$BASE/logs \
+    -v $ADI_WWWW/app/static/img/uploaded:$BASE/app/static/img/uploaded \
     -d \
     --name="$NAME" $NAME


### PR DESCRIPTION
When I rearranged the docker images, I forgot to update the mount volume
locations. That meant that the images weren't being uploaded to a host
volume, so all the images disappeared when we restarted the docker
container (by deploying, for example).

That means that all the images we uploaded in the last couple of days
are probably permanently missing.

Oops. :sob:

r? @evantarrh @schlosser @RaymondXu @eunicekokor 